### PR TITLE
Remove depreciation

### DIFF
--- a/Tweak/Tweak.xm
+++ b/Tweak/Tweak.xm
@@ -176,10 +176,10 @@ NSInteger style;
     ];
 
     [alertController addAction:[UIAlertAction actionWithTitle:@"Damn!" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-        [((UIApplication*)self).keyWindow.rootViewController dismissViewControllerAnimated:YES completion:NULL];
+        [((UIApplication*)self).windows.firstObject.rootViewController dismissViewControllerAnimated:YES completion:NULL];
     }]];
 
-    [((UIApplication*)self).keyWindow.rootViewController presentViewController:alertController animated:YES completion:NULL];
+    [((UIApplication*)self).windows.firstObject.rootViewController presentViewController:alertController animated:YES completion:NULL];
 }
 
 %end


### PR DESCRIPTION
keyWindow was deprecated in iOS 13.